### PR TITLE
Allow seven-figure row numbers in A1 references

### DIFF
--- a/R/A1-R1C1-regex-utils.R
+++ b/R/A1-R1C1-regex-utils.R
@@ -1,7 +1,7 @@
 .cr <- new.env(parent = emptyenv())
 
 ## for validating single cell references
-.cr$A1_rx <- "^\\$?[A-Za-z]{1,3}\\$?[0-9]{1,5}$"
+.cr$A1_rx <- "^\\$?[A-Za-z]{1,3}\\$?[0-9]{1,7}$"
 .cr$R1C1_rx <- "^R\\[?\\-?[0-9]*\\]?C\\[?\\-?[0-9]*\\]?$"
 
 #' Test cell reference strings

--- a/tests/testthat/test-A1-R1C1-utils.R
+++ b/tests/testthat/test-A1-R1C1-utils.R
@@ -1,6 +1,6 @@
 context("A1, R1C1 detection and parsing")
 
-A1 <- c("A1", "$A1", "A$1", "$A$1", "a1")
+A1 <- c("A1", "$A1", "A$1", "$A$1", "a1", "A1048576")
 R1C1 <- c("R1C1", "R1C[-1]", "R[-1]C1", "R[-1]C[9]")
 
 test_that("A1 refs are detected as such and R1C1 are not", {


### PR DESCRIPTION
Excel xlsx files allow up to 1048576 rows